### PR TITLE
Update Discord URLs to permanent invite link

### DIFF
--- a/cmd/index.html
+++ b/cmd/index.html
@@ -41,7 +41,7 @@
                 <div class="w3-dropdown-content w3-bar-block w3-card-4">
                     <a href="https://docs.h1.gg" class="w3-bar-item w3-button"><i class="fa fa-book"></i> - Docs</a>
                     <a href="https://github.com/h1-mod/h1-mod" class="w3-bar-item w3-button"><i class="fab fa-github"></i> - Github</a>
-                    <a href="https://discord.gg/h1-mod" class="w3-bar-item w3-button"><i class="fab fa-discord"></i> - Discord</a>
+                    <a href="https://discord.com/invite/RzzXu5EVnh" class="w3-bar-item w3-button"><i class="fab fa-discord"></i> - Discord</a>
                 </div>
             </div>
         </nav>
@@ -234,7 +234,7 @@ tr:last-child td {
             <p class="footer-title">H1-Mod <span style="color: #19c34c;"><i class="fas fa-code"></i></span></p>
             <center><p class="footer-desc">H1-Mod 1.15 is not affiliated with Activision-Blizzard Inc, Infinity Ward or Raven Software. All rights belong to their respective owners.</p></center>
             <div class="social-icons">
-                <a href="https://discord.gg/h1-mod"><i class="fab fa-discord"></i></a>
+                <a href="https://discord.com/invite/RzzXu5EVnh"><i class="fab fa-discord"></i></a>
                 <a href="https://github.com/h1-mod"><i class="fab fa-github"></i></a>
             </div>
         </footer>

--- a/donate/index.html
+++ b/donate/index.html
@@ -41,7 +41,7 @@
                 <div class="w3-dropdown-content w3-bar-block w3-card-4">
                     <a href="https://docs.h1.gg" class="w3-bar-item w3-button"><i class="fa fa-book"></i> - Docs</a>
                     <a href="https://github.com/h1-mod/h1-mod" class="w3-bar-item w3-button"><i class="fab fa-github"></i> - Github</a>
-                    <a href="https://discord.gg/h1-mod" class="w3-bar-item w3-button"><i class="fab fa-discord"></i> - Discord</a>
+                    <a href="https://discord.com/invite/RzzXu5EVnh" class="w3-bar-item w3-button"><i class="fab fa-discord"></i> - Discord</a>
                 </div>
             </div>
         </nav>
@@ -64,7 +64,7 @@
         <p class="footer-title">H1-Mod <span style="color: #19c34c;"><i class="fas fa-code"></i></span></p>
         <center><p class="footer-desc">H1-Mod 1.15 is not affiliated with Activision-Blizzard Inc, Infinity Ward or Raven Software. All rights belong to their respective owners.</p></center>
         <div class="social-icons">
-            <a href="https://discord.gg/h1-mod"><i class="fab fa-discord"></i></a>
+            <a href="https://discord.com/invite/RzzXu5EVnh"><i class="fab fa-discord"></i></a>
             <a href="https://github.com/h1-mod"><i class="fab fa-github"></i></a>
         </div>
     </footer>

--- a/errors/index.html
+++ b/errors/index.html
@@ -41,7 +41,7 @@
                 <div class="w3-dropdown-content w3-bar-block w3-card-4">
                     <a href="https://docs.h1.gg" class="w3-bar-item w3-button"><i class="fa fa-book"></i> - Docs</a>
                     <a href="https://github.com/h1-mod/h1-mod" class="w3-bar-item w3-button"><i class="fab fa-github"></i> - Github</a>
-                    <a href="https://discord.gg/h1-mod" class="w3-bar-item w3-button"><i class="fab fa-discord"></i> - Discord</a>
+                    <a href="https://discord.com/invite/RzzXu5EVnh" class="w3-bar-item w3-button"><i class="fab fa-discord"></i> - Discord</a>
                 </div>
             </div>
         </nav>
@@ -80,7 +80,7 @@
         <p class="footer-title">H1-Mod <span style="color: #19c34c;"><i class="fas fa-code"></i></span></p>
         <center><p class="footer-desc">H1-Mod 1.15 is not affiliated with Activision-Blizzard Inc, Infinity Ward or Raven Software. All rights belong to their respective owners.</p></center>
         <div class="social-icons">
-            <a href="https://discord.gg/h1-mod"><i class="fab fa-discord"></i></a>
+            <a href="https://discord.com/invite/RzzXu5EVnh"><i class="fab fa-discord"></i></a>
             <a href="https://github.com/h1-mod"><i class="fab fa-github"></i></a>
         </div>
     </footer>

--- a/faq/index.html
+++ b/faq/index.html
@@ -41,7 +41,7 @@
                 <div class="w3-dropdown-content w3-bar-block w3-card-4">
                     <a href="https://docs.h1.gg" class="w3-bar-item w3-button"><i class="fa fa-book"></i> - Docs</a>
                     <a href="https://github.com/h1-mod/h1-mod" class="w3-bar-item w3-button"><i class="fab fa-github"></i> - Github</a>
-                    <a href="https://discord.gg/h1-mod" class="w3-bar-item w3-button"><i class="fab fa-discord"></i> - Discord</a>
+                    <a href="https://discord.com/invite/RzzXu5EVnh" class="w3-bar-item w3-button"><i class="fab fa-discord"></i> - Discord</a>
                 </div>
             </div>
         </nav>
@@ -87,7 +87,7 @@
         <p class="footer-title">H1-Mod <span style="color: #19c34c;"><i class="fas fa-code"></i></span></p>
         <center><p class="footer-desc">H1-Mod 1.15 is not affiliated with Activision-Blizzard Inc, Infinity Ward or Raven Software. All rights belong to their respective owners.</p></center>
         <div class="social-icons">
-            <a href="https://discord.gg/h1-mod"><i class="fab fa-discord"></i></a>
+            <a href="https://discord.com/invite/RzzXu5EVnh"><i class="fab fa-discord"></i></a>
             <a href="https://github.com/h1-mod"><i class="fab fa-github"></i></a>
         </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
                 <div class="w3-dropdown-content w3-bar-block w3-card-4">
                   <a href="https://docs.h1.gg" class="w3-bar-item w3-button"><i class="fa fa-book"></i> - Docs</a>
                   <a href="https://github.com/h1-mod/h1-mod" class="w3-bar-item w3-button"><i class="fab fa-github"></i> - Github</a>
-                  <a href="https://discord.gg/h1-mod" class="w3-bar-item w3-button"><i class="fab fa-discord"></i> - Discord</a>
+                  <a href="https://discord.com/invite/RzzXu5EVnh" class="w3-bar-item w3-button"><i class="fab fa-discord"></i> - Discord</a>
                 </div>
             </div>
         </nav>
@@ -64,7 +64,7 @@
             <a href="https://docs.h1.gg" class="docs-btn"><i class="fa fa-book"></i> Documentation</a>
             <div class="social-icons">
                 <a href="https://github.com/h1-mod/h1-mod"><i class="fab fa-github"></i></a>
-                <a href="https://discord.gg/h1-mod"><i class="fab fa-discord"></i></a>
+                <a href="https://discord.com/invite/RzzXu5EVnh"><i class="fab fa-discord"></i></a>
             </div>
         </div>
     </section>
@@ -184,7 +184,7 @@
         <p class="footer-title">H1-Mod <span style="color: #19c34c;"><i class="fas fa-code"></i></span></p>
         <center><p class="footer-desc">H1-Mod 1.15 is not affiliated with Activision-Blizzard Inc, Infinity Ward or Raven Software. All rights belong to their respective owners.</p></center>
         <div class="social-icons">
-            <a href="https://discord.gg/h1-mod"><i class="fab fa-discord"></i></a>
+            <a href="https://discord.com/invite/RzzXu5EVnh"><i class="fab fa-discord"></i></a>
             <a href="https://github.com/h1-mod"><i class="fab fa-github"></i></a>
         </div>
     </footer>


### PR DESCRIPTION
As the H1-Mod custom Discord invite link no longer works, this PR updates any references to it in the repository to the permanent Discord invite link.

The new invite link is the one in README.md in the h1-mod/h1-mod repository.