### PR TITLE
home page overhaul

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,8 +24,7 @@
 </head>
 <body>
     <header>
-        <a href="https://h1.gg" class="logo"><h3 style="margin-left: 100px;    display: inline-block;
-            margin-top: 10px;color: #19c34c;font-size: 1em;font-weight: 600;border: 1px; border-color: #fff;"><span><i class="fa fa-h1"></i></span></h3></a>
+        <a href="https://h1.gg" class="logo"><h3><span><i class="fa fa-h1"></i></span></h3></a>
         <nav class="navigation">
             <div class="w3-dropdown-hover w3-hide-small">
                 <button class="w3-padding-large w3-button" title="SUPPORT">H1-Mod <i class="fas fa-angle-down"></i></button>
@@ -58,7 +57,7 @@
     <section class="main">
         <div>
             <h2><span>H1-Mod</span></h2>
-            <h3>A client for Call of Duty: Modern Warfare Remastered.</h3>
+            <h3>A client for Call of Duty: Modern Warfare Remastered.</h3>
             <a href="https://docs.h1.gg/install" class="main-btn"><i class="fa fa-download"></i> Download</a>
             <a href="https://docs.h1.gg" class="docs-btn"><i class="fa fa-book"></i> Documentation</a>
             <div class="social-icons">
@@ -86,7 +85,7 @@
                 </div>
                 <div class="info">
                     <h3>Scripting Support</h3>
-                    <p>Integrating the official scripting language used in Call of Duty for basic mod support.</p>
+                    <p>Integrating the official scripting language used in Call of Duty for basic mod support.</p>
                 </div>
             </div>
             <div class="card">
@@ -95,7 +94,7 @@
                 </div>
                 <div style="height: 100px;"><div class="info">
                     <h3>Controller Support</h3>
-                    <p>Full controler support with the option of aim assist.</p>
+                    <p>Full controller support with the option of aim assist.</p>
                 </div></div>
             </div>
         </div>
@@ -112,7 +111,7 @@
                     <strong class="features-title">
                         <span>Server List <i class="fas fa-list-ul"></i></span>
                     </strong>
-                    <p class="features-category">Join any dedicated server with the new server browser! Offers a easy experience to find community-ran servers that can be any map or gamemode.</p>
+                    <p class="features-category">Join any dedicated server with the new server browser! Offers a easy experience to find community-ran servers that can be any map or game mode.</p>
                 </div>
             </div>
             <div class="features-card">
@@ -167,7 +166,7 @@
                     <strong class="features-title">
                         <span>and more! <i class="fas fa-meteor"></i></span>
                     </strong>
-                    <p class="features-category">We've added alot of fun stuff such as bouncing, elevators, cheat commands (noclip, godmode, etc.), and support to make custom content/materials!</p>
+                    <p class="features-category">We've added a lot of fun stuff such as bouncing, elevators, cheat commands (noclip, godmode, etc.), and support to make custom content/materials!</p>
                 </div>
             </div>
         </div>
@@ -175,10 +174,10 @@
 
     <footer class="footer">
         <p class="footer-title">H1-Mod <span style="color: #19c34c;"><i class="fas fa-code"></i></span></p>
-        <p class="footer-desc">H1-Mod is not affiliated with Activision-Blizzard Inc, Infinity Ward or Raven Software. All rights belong to their respective owners.</p>
+        <p class="footer-desc">H1-Mod is not affiliated with Activision Blizzard Inc, Infinity Ward or Raven Software. All rights belong to their respective owners.</p>
         <div class="social-icons">
-            <a href="https://discord.com/invite/RzzXu5EVnh"><i class="fab fa-discord"></i></a>
             <a href="https://github.com/h1-mod/h1-mod"><i class="fab fa-github"></i></a>
+            <a href="https://discord.com/invite/RzzXu5EVnh"><i class="fab fa-discord"></i></a>
         </div>
     </footer>
 </body>

--- a/style.css
+++ b/style.css
@@ -1,21 +1,12 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Fira+Mono&display=swap');
 
 * {
-    font-family: 'Poppins', sans-serif;
+    font-family: Montserrat, Poppins, Century Gothic, sans-serif;
     margin: 0;
     padding: 0;
     box-sizing: border-box;
     scroll-behavior: smooth; 
-}
-
-@font-face {
-    font-family: fira_mono_bold;
-    src: url(https://raw.githubusercontent.com/skkuull/h1_dump/main/h1_dump/fonts/fira_mono_bold.ttf);
-}
-
-@font-face {
-    font-family: fira_mono_regular;
-    src: url(https://raw.githubusercontent.com/skkuull/h1_dump/main/h1_dump/fonts/fira_mono_regular.ttf);
 }
 
 /* Credits to Evan/Eve or https://emosewaj.eu/status */
@@ -51,6 +42,13 @@
     }
 }
 
+@media (orientation:portrait) {
+    .fullscreen-bg__video {
+        width: 100%;
+        object-fit: cover;
+    }
+}
+
 body {
     background-attachment: fixed;
     margin: 0;
@@ -58,15 +56,16 @@ body {
 
 header {
     backdrop-filter: blur(25px);
-    background-color: rgba(255, 255, 255, 0.078);
+    background-color: rgba(0, 0, 0, 0.2);
     width: 100%;
     height: 7%;
+    min-height: 46px;
     position: fixed;
     z-index: 999;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 10px 100px ;
+    padding: 10px 100px;
 }
 
 .logo{
@@ -112,7 +111,6 @@ section {
 }
 
 .main h2 span {
-    /* font-family: fira_mono_bold; */
     display: inline-block;
     margin-top: 10px;
     color: #49E879;
@@ -129,50 +127,32 @@ section {
     margin-bottom: 30px;
 }
 
-.maindl-btn {
-    color: #fff;
-    background-color: #26a34b;
-    text-decoration: none;
-    font-size: 1.1em;
-    font-weight: 600;
-    display: inline-block;
-    padding: 0.9375em 2.1875em;
-    letter-spacing: 1px;
-    border-radius: 8px;
-    margin-bottom: 40px;
-    transition: 0.7s ease;
-}
-
-.maindl-btn:hover {
-    box-shadow: inset 0 0 100px 100px rgba(255, 255, 255, 0.1);
-}
-
 .docs-btn {
-    color: #fff;
+    color: black;
     background-color: #54cf79c1;
     text-decoration: none;
     font-size: 1.1em;
     font-weight: 600;
     display: inline-block;
     padding: 0.9375em 2.1875em;
-    letter-spacing: 1px;
+    letter-spacing: 0.5px;
     border-radius: 8px;
     margin-bottom: 40px;
     transition: 0.7s ease;
 }
 
-.docs-btn:hover {
-    box-shadow: inset 0 0 100px 100px rgba(255, 255, 255, 0.1);
+.main-btn:hover, .docs-btn:hover {
+    box-shadow: inset 0 0 100px 100px rgba(255, 255, 255, 0.65);
 }
 
 .main-btn {
-    color: #fff;
+    color: black;
     text-decoration: none;
     font-size: 1.1em;
     font-weight: 600;
     display: inline-block;
     padding: 0.9375em 2.1875em;
-    letter-spacing: 1px;
+    letter-spacing: 0.5px;
     border-radius: 10px;
     margin-bottom: 40px;
     transition: 0.7s ease;
@@ -185,7 +165,7 @@ section {
     background-color: rgba(0, 0, 0, 0.2);
     border: 3px solid;
 }
-  
+
 @keyframes colorRotate {
     from {
         background-color: #a8ff66;
@@ -207,7 +187,6 @@ section {
 .footer .social-icons a:hover{
     font-size: 1.3em;
     padding-left: 0 20px 0 0;
-
     color: rgba(255, 255, 255, 0.544);
 }
 
@@ -217,10 +196,12 @@ section {
     padding-right: 30px;
 }
 
+.social-icons {
+    white-space: nowrap;
+}
+
 .social-icons a:hover {
     color: #fff;
-    font-size: 1.7em;
-    padding-right: 30px;
 }
 
 /* color: rgba(255, 255, 255, 0.544); */
@@ -231,7 +212,12 @@ section {
     color: #26a34b;
     font-size: 2.2em;
     font-weight: 800;
-    margin-bottom: 30px;
+}
+
+@media (min-width:641px){
+    .title {
+        margin-bottom: 30px;
+    }
 }
 
 .content {
@@ -265,27 +251,26 @@ section {
     margin-bottom: 5px;
     color: #fff;
     display: inline-block;
-    
 }
 
 .form__inner input[type="text"],
 .form__inner textarea {
-  outline: none;
-  width: 55%;
-  font-size: 16px;
-  line-height: 20px;
-  margin-bottom: 15px;
-  color: #333;
-  padding: 12px 20px;
-  font-family: inherit;
-  text-align: left;
-  -webkit-appearance: none;
-  background: rgba(255, 154, 66, 0.02);
-  display: grid;
-  align-items: center;
-  padding-left: 10px;
-  border: 1px solid #ccc;
-  border-radius: 3px;
+    outline: none;
+    width: 55%;
+    font-size: 16px;
+    line-height: 20px;
+    margin-bottom: 15px;
+    color: #333;
+    padding: 12px 20px;
+    font-family: inherit;
+    text-align: left;
+    -webkit-appearance: none;
+    background: rgba(255, 154, 66, 0.02);
+    display: grid;
+    align-items: center;
+    padding-left: 10px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
 }
 
 .script {
@@ -301,23 +286,24 @@ section {
     box-shadow: inset 0 0 2000px rgba(200, 200, 200, 0.272);
 }
 
-.script p {
-    font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
-    color: #fff;
-}
-
 .cards {
     background-color: #040404;
 }
 
 .card {
-    width: 21.25em;
     border-radius: 10px;
     border: 1px solid #303436;
-    padding: 25px;
+    padding: 10px;
     margin: 15px;
     transition: 0.7s ease;
     background: inherit;
+}
+
+@media (min-width: 350px) {
+    .card {
+        width: 21.25em;
+        padding: 25px;
+    }
 }
 
 .card:before {
@@ -353,8 +339,8 @@ section {
     background-attachment: fixed;
 }
 
-.features span {
-    font-family: fira_mono_regular;
+.features span, .script p {
+    font-family: Fira Mono, Fira Code, monospace;
     color: #fff;
 }
 
@@ -363,33 +349,48 @@ section {
     margin-top: 1ch;
 }
 
-.features .content{
-    margin-top: 30px;
+@media (min-width: 800px) {
+    .features .content {
+        margin-top: 30px;
+    }
 }
 
 .features-card {
     background-color: #131516;
     border: 1px solid #303436;
     min-height: 14em;
-    width: 23em;
     overflow: hidden;
     border-radius: 10px;
     margin: 20px;
     transition: 0.7s ease;
 }
 
-.features-card:hover {
-    transform: scale(1.2);
+@media (max-width: 350px) {
+    .features-card, .card {
+        min-width: 75vw;
+    }
 }
 
 .features-card:hover .features-image {
+    opacity: 1;
+}
+
+.features-card .features-image {
     opacity: 0.9;
- }
+}
+
+@media (min-width: 350px) {
+    .features-card {
+        width: 23em;
+    }
+    .features-card:hover {
+        transform: scale(1.2);
+    }
+}
 
 .features-image img{
     width: 100%;
     border-radius: 5px;
-    cursor: pointer;
     transition: 0.3s;
 }
 
@@ -432,12 +433,10 @@ section {
 }
 
 .footer {
-    backdrop-filter: blur(10px);
     background-color: rgb(18, 18, 18);
     background-size: cover;
     background-position: center;
     background-attachment: fixed;
-    backdrop-filter: 10px;
     color: #fff;
     padding: 2em;
     display: flex;
@@ -447,12 +446,14 @@ section {
 .footer-title {
     font-size: 1.3em;
     font-weight: 600;
+    white-space: nowrap;
 }
 
 .footer-desc {
     font-size: 0.8em;
-    font-weight: 400;
-    padding-left: 50px;
+    padding-left: 25px;
+    padding-right: 25px;
+    margin: auto;
 }
 
 .footer-title span {
@@ -461,8 +462,6 @@ section {
 
 .footer .social-icons a{
     font-size: 1.3em;
-    padding-left: 0 20px 0 0;
-    
 }
 
 @media (max-width:1023px){
@@ -509,12 +508,91 @@ section {
     .main-content h3{
         font-size: 1.4em;
     }
+
+    section {
+        padding: 50px 20px;
+    }
 }
 
-@media (max-width:300px){
+@media (max-width: 300px){
     body{
         font-size: 10px;
-     
+    }
+    .main-btn, .docs-btn {
+        letter-spacing: 0;
+    }
+}
+
+header a.logo h3 {
+    margin-left: 100px;
+    display: inline-block;
+    margin-top: 10px;
+    color: #19c34c;
+    font-size: 1em;
+    font-weight: 600;
+    border: 1px;
+    border-color: #fff;
+}
+
+@media (max-width: 1023px) {
+    header a.logo h3 {
+        margin-left: 0;
+    }
+}
+
+@media (max-width: 270px) or (max-height: 230px) {
+    header {
+        justify-content: center;
+    }
+    .w3-hide-small {
+        display: none !important
+    }
+}
+
+@media (orientation:portrait) {
+    .footer {
+        padding: 1.25em;
+        display: grid;
+    }
+    .footer-desc {
+        padding: inherit;
+    }
+    .footer-title {
+        margin: auto;
+    }
+    .social-icons a {
+        padding-left: 15px;
+        padding-right: 15px;
+    }
+    .social-icons {
+        white-space: nowrap;
+        margin: auto;
+    }
+    section.main, .footer-desc {
+        text-align: center;
+    }
+    .main-btn, .docs-btn {
+        margin-bottom: 15px;
+        width: 55%
+    }
+    .main {
+        width: 100%
+    }
+    .main h2 span {
+        font-size: 13.5vw;
+    }
+    .main h3 {
+        font-size: 4.5vw;
+    }
+    .features-card, .card {
+        margin: 10px 0px;
+    }
+}
+
+@media (max-width: 390px) {
+    .main-btn, .docs-btn
+    {
+        width: 100%
     }
 }
 
@@ -529,9 +607,9 @@ section {
 }
 
 ::-webkit-scrollbar-thumb {
-    background: #49E879; 
+    background: #49E879;
 }
-  
+
 ::-webkit-scrollbar-thumb:hover {
-    background: #128d37; 
+    background: #128d37;
 }

--- a/w3.css
+++ b/w3.css
@@ -229,7 +229,7 @@ h6 {
 }
 
 h1,h2,h3,h4,h5,h6 {
-    font-family: "Segoe UI",Arial,sans-serif;
+    font-family: Segoe UI,SegoeUI,Selawik,Helvetica Neue,Helvetica,Arial,sans-serif;
     font-weight: 400;
     margin: 10px 0
 }
@@ -424,7 +424,8 @@ a {
 
 .w3-dropdown-hover:hover > .w3-button:first-child,.w3-dropdown-click:hover > .w3-button:first-child {
     background-color: #1B1B1B;
-    color: #fff
+    color: #fff;
+    cursor: default;
 }
 /* hey 111 */
 
@@ -772,6 +773,12 @@ a {
     }
 }
 
+@media (max-width: 270px) {
+    .w3-hide-small {
+        display: none !important
+    }
+}
+
 @media (max-width: 600px) {
     .w3-modal-content {
         margin:0 10px;
@@ -784,10 +791,6 @@ a {
 
     .w3-dropdown-hover.w3-mobile .w3-dropdown-content,.w3-dropdown-click.w3-mobile .w3-dropdown-content {
         position: relative
-    }
-
-    .w3-hide-small {
-        display: none!important
     }
 
     .w3-mobile {


### PR DESCRIPTION
* Optimization and fixes for portrait screens
* Main font: replaced Poppins with Montserrat → it looks more similar to logo font and contains more glyphs
* Reduced page loading time thanks to using Fira Mono from Google Fonts (optimized for Web)
* Improved Segoe UI font stack, added Fira Mono font stack
* Much better contrast for main-btn (1.3→15.8) and docs-btn (2.8→7.4)
* Darkening for header → better contrast and more similar to H1 style
* Minor fixes, cleanup

https://user-images.githubusercontent.com/13555921/210502747-b2e6048e-1d18-434b-9edb-96edf3d4afc3.mp4

